### PR TITLE
Set butter-provider-vodo version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "butter-provider-anime": "1.0.0",
     "butter-provider-movies": "1.0.3",
     "butter-provider-tvapi": "git+https://github.com/team-pct/butter-provider-tvapi",
-    "butter-provider-vodo": "git+https://github.com/butterproviders/butter-provider-vodo",
+    "butter-provider-vodo": "0.3.1",
     "butter-settings-popcorntime.io": "git+https://github.com/popcorn-official/butter-settings-popcorn",
     "chromecasts": "1.9.0",
     "defer-request": "0.0.2",


### PR DESCRIPTION
Actually butter-provider-vodo version set in package.json use the master branch of the repo.
Recently some changes were made on it which generate issue with PT. (PT start with black empty window)
Settings version to 0.3.1 will use the package provided by npmjs, which is the same version than before it was recently updated.
Fix issues #741, #770.
